### PR TITLE
Release v1.1.0

### DIFF
--- a/cmd/s3csi/build.sh
+++ b/cmd/s3csi/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-tag="release-v0.0.0.22"
+tag="v1.1.0-95174bddef2"
 
 go build
 

--- a/cmd/s3csi/build.sh
+++ b/cmd/s3csi/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-tag="v1.1.0-95174bddef2"
+tag="release-v1.1.0.3"
 
 go build
 

--- a/cmd/s3csi/build.sh
+++ b/cmd/s3csi/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-tag="release-v1.1.0.3"
+tag="v1.1.0"
 
 go build
 

--- a/deploy/s3-csi/templates/daemonset.yaml
+++ b/deploy/s3-csi/templates/daemonset.yaml
@@ -25,10 +25,6 @@ spec:
             - --nodeId=$(NODE_NAME)
             - --v=5
           env:
-            - name: AWS_ACCESS_KEY_ID
-              value: {{ .Values.minio.accessKey }}
-            - name: AWS_SECRET_ACCESS_KEY
-              value: {{ .Values.minio.accessSecret }}
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: NODE_NAME

--- a/deploy/s3-csi/templates/storageclass.yaml
+++ b/deploy/s3-csi/templates/storageclass.yaml
@@ -5,7 +5,7 @@ metadata:
 provisioner: minio.s3.csi.xw.com
 parameters:
   mounter: mount-s3
-  bucket: k8s-dev-sc
-  access-key: admin
-  secret-key: minioadmin
-  endpoint: 10.20.121.41:30629
+  bucket: {{ .Values.minio.bucket }}
+  access-key: {{ .Values.minio.accessKey }}
+  secret-key: {{ .Values.minio.accessSecret }}
+  endpoint: {{ .Values.minio.url }}

--- a/deploy/s3-csi/values.yaml
+++ b/deploy/s3-csi/values.yaml
@@ -3,6 +3,7 @@ global:
   tag: v1.1.0-95174bddef2
 
 minio:
-  url: http://10.20.121.41:30629
+  url: 10.20.121.41:30629
   accessKey: admin
   accessSecret: minioadmin
+  bucket: k8s-dev-sc

--- a/deploy/s3-csi/values.yaml
+++ b/deploy/s3-csi/values.yaml
@@ -1,6 +1,6 @@
 global:
   image: xwharbor.wxchina.com/cpaas-dev/component/csi-s3
-  tag: release-v0.0.0.22
+  tag: v1.1.0-95174bddef2
 
 minio:
   url: http://10.20.121.41:30629

--- a/deploy/s3-csi/values.yaml
+++ b/deploy/s3-csi/values.yaml
@@ -1,6 +1,6 @@
 global:
   image: xwharbor.wxchina.com/cpaas-dev/component/csi-s3
-  tag: v1.1.0-95174bddef2
+  tag: release-v1.1.0.3
 
 minio:
   url: 10.20.121.41:30629

--- a/deploy/s3-csi/values.yaml
+++ b/deploy/s3-csi/values.yaml
@@ -1,6 +1,6 @@
 global:
   image: xwharbor.wxchina.com/cpaas-dev/component/csi-s3
-  tag: release-v1.1.0.3
+  tag: v1.1.0
 
 minio:
   url: 10.20.121.41:30629

--- a/deploy/test/nginx-pod.yaml
+++ b/deploy/test/nginx-pod.yaml
@@ -14,8 +14,6 @@ spec:
       labels:
         app: nginx
     spec:
-      nodeSelector:
-        kubernetes.io/hostname: h-10-20-121-130-dev-k8s-node
       containers:
         - image: xwharbor.wxchina.com/cpaas-pub/nginx:1.24.0
           name: nginx

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -57,6 +57,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	mnt := s3.NewRclone(req)
 	err = mnt.Mount(volumeId, target)
+	klog.V(4).Info("Rclone mount command execute finish!")
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -104,7 +104,6 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	return nil, status.Error(codes.Unimplemented, "")
 }
 
-// TODO 看到Pod里面其实没有创建/var/lib/kubelet/pods/d51de966-1a5f-4d35-843a-56b5e4cf6ed2/volumes/kubernetes.io~csi/pvc-967ee658-01ec-445c-ac7f-6fb058e22c7b/mount 后面这个路径，问题出现在这个地方
 func checkMount(path string) (bool, error) {
 	err := mkDirAll(path)
 	if err != nil {

--- a/pkg/s3/mountpoint.go
+++ b/pkg/s3/mountpoint.go
@@ -57,8 +57,6 @@ func (m *MountpointS3) Unstage(path string) error {
 }
 
 func (m *MountpointS3) Mount(source string, target string) error {
-	os.Setenv(AwsAccessKeyId, m.accessKey)
-	os.Setenv(AwsSecretAccessKey, m.secretKey)
 	url := m.endpointUrl()
 	args := []string{
 		"--endpoint-url=" + url,
@@ -69,6 +67,12 @@ func (m *MountpointS3) Mount(source string, target string) error {
 	}
 
 	cmd := exec.Command(mountS3Command, args...)
+	envs := []string{
+		"AWS_ACCESS_KEY_ID=" + m.accessKey,
+		"AWS_SECRET_ACCESS_KEY=" + m.secretKey,
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(cmd.Environ(), envs...)
 	klog.V(4).Infof("Mount fuse with command:%s and args:%s", mountS3Command, args)
 
 	if err := cmd.Run(); err != nil {

--- a/pkg/s3/rclone.go
+++ b/pkg/s3/rclone.go
@@ -56,6 +56,7 @@ func (r *Rclone) Mount(source string, target string) error {
 		"--vfs-cache-max-size=10G",
 		"--vfs-read-chunk-size-limit=100M",
 		"--buffer-size=100M",
+		"--daemon",
 	}
 	envs := []string{
 		"AWS_ACCESS_KEY_ID=" + r.accessKey,

--- a/pkg/s3/rclone.go
+++ b/pkg/s3/rclone.go
@@ -42,8 +42,6 @@ func (r *Rclone) Unstage(path string) error {
 }
 
 func (r *Rclone) Mount(source string, target string) error {
-	os.Setenv(AwsAccessKeyId, r.accessKey)
-	os.Setenv(AwsSecretAccessKey, r.secretKey)
 	url := r.endpointUrl()
 
 	args := []string{
@@ -59,8 +57,13 @@ func (r *Rclone) Mount(source string, target string) error {
 		"--vfs-read-chunk-size-limit=100M",
 		"--buffer-size=100M",
 	}
+	envs := []string{
+		"AWS_ACCESS_KEY_ID=" + r.accessKey,
+		"AWS_SECRET_ACCESS_KEY=" + r.secretKey,
+	}
 	cmd := exec.Command(rcloneCommand, args...)
 	cmd.Stderr = os.Stderr
+	cmd.Env = append(cmd.Environ(), envs...)
 	klog.V(4).Infof("Rclone with command:%s and args:%s", rcloneCommand, args)
 
 	if out, err := cmd.Output(); err != nil {


### PR DESCRIPTION
1.修复了rclone执行mount的时候，没有携带--daemon参数，导致k8s调用NodePublishVolume接口的时候，出现Grpc的DeadlineContext=4 (超时)的情况，但是mount还是正常可以使用的，只是Pod的启动时长过长，超过3分钟
2.Minio的accessKey和secretKey参数不在通过Daemon的env形式传入，而是通过StorageClass的配置参数传入，减少了ak和sk的泄漏(目前还是有点泄漏，后续准备使用secret的形式)